### PR TITLE
change -Xmx

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.configureoncommand=true
 org.gradle.parallel.threads=4
-org.gradle.jvmargs=-Xmx8G
+org.gradle.jvmargs=-Xmx1G


### PR DESCRIPTION
fixes
```
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
Invalid maximum heap size: -Xmx8G
The specified size exceeds the maximum representable size.
```